### PR TITLE
Docs for gtparse

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -11,13 +11,26 @@ Glossary
       chunk looks like.
       
    fuzzy
-      FIXME
-      
+      Fuzzy if a flag that can be set programmatically when extracting strings
+      for translation or manually by the translator. It is used to indicate
+      that the translation may no longer be valid. Once the translator has
+      reviewed (and possibly corrected) the string, the flag is removed.
+
+      See the `gettext reference documentation
+      <http://www.gnu.org/software/gettext/manual/html_node/Fuzzy-Entries.html#Fuzzy-Entries>`_
+      for details.
+
    gettext catalog
       A gettext catalog is a collection of gettext :term:`message` s and a
       header with metadata. It is most often contained in a .po file. The
       header is the message with and empty :term:`msgid` and is usually the
-      first message of the file.
+      first message of the file. In pyg3t a gettext catalog is represented by
+      the :py:class:`pyg3t.gtparse.Catalog` class.
+      
+      See the `gettext reference documentation
+      <http://www.gnu.org/software/gettext/manual/html_node/PO-Files.html#PO-Files>`_
+      for details.
+
 
    message
       A message refers to all data and metadata pertaining to a single
@@ -25,7 +38,9 @@ Glossary
       :term:`msgid` (original string) and the :term:`msgstr` (translated
       string), both of which can optionally have plural forms. The metadata
       consist of references to source code lines for the msgids and optionally
-      a comment, context and a previous version of the msgid.
+      a comment, context and a previous version of the msgid. In pyg3t a
+      message is represented by the classes :py:class:`pyg3t.gtparse.Message`
+      and :py:class:`pyg3t.gtparse.ObsoleteMessage`.
 
       A typical message could look like this (inspired by the Danish translation
       of nautilus) (FIXME better example):
@@ -35,13 +50,25 @@ Glossary
         # Ahh, nautilus can run programs
         #: ../data/nautilus-autorun-software.desktop.in.in.h:1
         msgid "Run Software"
-        msgstr "Kør programmer"	    
+	msgstr "Kør programmer"
+
+      See the `gettext reference documentation
+      <http://www.gnu.org/software/gettext/manual/html_node/PO-Files.html#PO-Files>`_
+      for details.
 
    msg
       See :term:`message`
 
    msgid
-      FIXME
+      The original string (usually in english), which is to be translated.
+
+      See the `gettext reference documentation
+      <http://www.gnu.org/software/gettext/manual/html_node/PO-Files.html#PO-Files>`_
+      for details.
 
    msgstr
-      FIXME
+      The translated string.
+
+      See the `gettext reference documentation
+      <http://www.gnu.org/software/gettext/manual/html_node/PO-Files.html#PO-Files>`_
+      for details.

--- a/pyg3t/gtparse.py
+++ b/pyg3t/gtparse.py
@@ -151,6 +151,7 @@ def parse_header_data(msg):
 
 
 def _get_header(msgs):
+    """Find and return the header :term:`message` in a iterable of messages"""
     for msg in msgs:
         if msg.msgid == '':
             msg.meta['headers'] = parse_header_data(msg)
@@ -256,40 +257,43 @@ class Catalog(object):
 class Message(object):
     """This class represents a po-file entry. 
 
-    Contains attributes that describe:
+    Parameters:
+        msgid (str): The :term:`msgid`
+        msgstr (str or list): The translated :term:`msgstr` s
+        msgid_plural (str): msgid plural if any, otherwise None
+        msgctxt (str): Context message of any, otherwise None
+        comments (list): Newline-terminated strings ([] or None if none)
+        meta (dict): Optional metadata (linenumber, raw text from po-file)
+        flags (iterable): Strings specififying flags ('fuzzy', etc.)
 
-    * msgid (possibly plural)
-    * msgstr(s)
-    * comments
-    * miscellaneous informations (flags, translation status)"""
+    If this message was loaded from a file using the parse() function,
+    the meta dictionary will contain the following keys:
+
+     * 'lineno': the original line number of the message in the po-file
+     * 'encoding': the encoding of the po-file
+     * 'rawlines': the original text in the po-file as a a list of
+       newline-terminated lines
+
+     It is understood that the properties of a Message may be
+     changed programmatically so as to render it inconsistent with
+     its rawlines and/or lineno.
+
+    Attributes:
+        msgid (str): The :term:`msgid`
+        msgid_plural (str): The plural msgid if any, otherwise None
+        msgstr (list): The translated :term:`msgstr` s
+        comments (list): Newline terminated comments strs
+        msgctxt (str): The msgid context if any, otherwise None
+        flags (set): Flags (strs) that are set if they are present
+        previous_msgid (str): The previous msgid if any, otherwise None
+        is_obsolete (bool): Whether the message is obsolete
+    """
 
     is_obsolete = False
 
     def __init__(self, msgid, msgstr, msgid_plural=None,
                  msgctxt=None, comments=None, meta=None,
                  flags=None, previous_msgid=None):
-        """Create a Message, representing one message from a message catalog.
-        
-        Parameters:
-         * msgid: string
-         * msgstr: string, or list of strings for plurals
-         * msgid_plural: None, or a string if there are plurals
-         * msgctxt: None, or a string if there is a message context
-         * comments: list of newline-terminated strings ([] or None if none)
-         * meta: dict of optional metadata (linenumber, raw text from po-file)
-         * flags: an iterable of strings specififying flags ('fuzzy', etc.)
-
-         If this message was loaded from a file using the parse() function,
-         the meta dictionary will contain the following keys:
-          * 'lineno': the original line number of the message in the po-file
-          * 'encoding': the encoding of the po-file
-          * 'rawlines': the original text in the po-file as a a list of
-                        newline-terminated lines
-         
-         It is understood that the properties of a Message may be
-         changed programmatically so as to render it inconsistent with
-         its rawlines and/or lineno.
-        """
         self.msgid = msgid
         self.msgid_plural = msgid_plural
 
@@ -342,38 +346,51 @@ class Message(object):
 
     @property
     def msgstr(self):
+        """The :term:`msgstr` or the first of the plural translations if it is
+        a plural string
+        """
         return self.msgstrs[0]
 
     @property
     def untranslated(self):
+        """Whether the message is untranslated"""
         return self.msgstr == ''
 
     @property
     def fuzzyflag(self):
+        """Whether the :term:`fuzzy` flag is set"""
         return 'fuzzy' in self.flags
 
     @property
     def isfuzzy(self):
+        """Whether the message is :term:`fuzzy`"""
         return self.fuzzyflag and not self.untranslated
     
     @property
     def istranslated(self):
+        """Whether the message is translated"""
         return self.msgstr != '' and not self.fuzzyflag
     
     @property
     def has_context(self):
+        """Whether the message has context"""
         return self.msgctxt is not None
     
     @property
     def has_previous_msgid(self):
+        """Whether the message has a previous msgid"""
         return self.previous_msgid is not None
     
     @property
     def hasplurals(self):
+        """Whether the message has plurals"""
         return self.msgid_plural is not None
 
     @property
     def key(self):
+        """A (msgid, msgctxt) tuple which can be considered a unique
+        (within the catalog) key for use e.g. in a dict
+        """
         return (self.msgid, self.msgctxt)
 
     def get_comments(self, pattern='', strip=False):


### PR DESCRIPTION
Ok, this was just meant as a short break from translating GNOME, but has now taken all spare time for a week. So it is not actually complete, but a good part of the work.

I have added the gtparse module to the API documentation page on our documentation and filled in sphinx napoleon suited docstring for a large part of the module (to the best of my understanding). These docstring must be reviewed to make sure that my understading is correct.

I have also added a glossary to the documentation, which I have made heavy use of.

I have also added inline comments to aid in my understanding of the code. For this I have tried to strike a balance with the aim of an inline comment per block that is not trivially understood at a glance. We can always discuss the aim and whether I have it the mark.

Napoleon is an extension for Sphinx, that makes it possible to write the docstrings, arguments, and return value entries in the google stryle (uses indent for syntax) instead of the original Sphinx restructured text. The has the huge advantage that docstrings written in the google style are actully readable in pure text, which is not really the case for those who format e.g. arguments with restructured text. More details about Napoleon is here: http://sphinx-doc.org/latest/ext/napoleon.html.

I have also made the default theme, the [Read The Docs](https://readthedocs.org/) theme, as it is intended to use that as the documentation platform and it is useful to be able to see the real theme.

Both Napoleon and the read the docs theme have been added to the development requirements and must be installed in order to be able to build the documentation. All development requirements can be installed in a virtual environment with ``pip install -r requirements-dev.txt``. If needed, the requirement of the read the docs theme could be relaxed by falling back to the default, but I don't think this is desirable.

Let me know what you think. Any corrections for the docstrings and inline comments can just be left here as inline comments for the PR diff.